### PR TITLE
add timestamp and frame_id to TwistStamped message

### DIFF
--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -597,6 +597,8 @@ void ControllerServer::computeAndPublishVelocity()
       nav_2d_utils::twist2Dto3D(twist),
       goal_checkers_[current_goal_checker_].get());
     last_valid_cmd_time_ = now();
+    cmd_vel_2d.header.frame_id = costmap_ros_->getBaseFrameID();
+    cmd_vel_2d.header.stamp = last_valid_cmd_time_;
     // Only no valid control exception types are valid to attempt to have control patience, as
     // other types will not be resolved with more attempts
   } catch (nav2_core::NoValidControl & e) {


### PR DESCRIPTION
The `frame_id` and `stamp` attribution was missing in this section.
I've seen the code alterations for TwistStamped in `nav2_behaviours` but it seems unnecessary to add `stamp` and `frame_id` there.

Here's a video of the topic published in the `ardupilot_ros` example, you can see that the message is complete now:

[Ardupilot_ros example with nav2](https://github.com/Ryanf55/navigation2/assets/62964137/c2bba0e4-93df-40e8-a7b1-6d1121346825)
